### PR TITLE
Fix long-table share layout and column count issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.7 进行中 预计2月15日之前发布
 
-- [ ] 修复长表格分享后布局错乱及列数显示异常的问题 [Issues 22](https://github.com/b8l8u8e8/siyuan-plugin-share/issues/22)
+- [x] 修复长表格分享后布局错乱及列数显示异常的问题 [Issues 22](https://github.com/b8l8u8e8/siyuan-plugin-share/issues/22)
 - [ ] 修复笔记本分享页在未加载文档时文档树位置偏上的布局偏移问题
 - [x] 内嵌 IFrame 支持全屏模式，并在右上角提供全屏切换及取消控件。 [Issues 23](https://github.com/b8l8u8e8/siyuan-plugin-share/issues/23)
 - [ ] 待反馈

--- a/php-site/assets/app.js
+++ b/php-site/assets/app.js
@@ -3131,7 +3131,6 @@ const initImageViewer = () => {
     usePlugin(window.markdownitSup);
     usePlugin(window.markdownitAbbr);
     usePlugin(window.markdownitIns);
-    usePlugin(window.markdownitMultimdTable);
     usePlugin(window.markdownItAnchor || window.markdownitAnchor, {permalink: false});
     registerCalloutSupport();
 

--- a/php-site/index.php
+++ b/php-site/index.php
@@ -1246,7 +1246,6 @@ function render_page(string $title, string $content, ?array $user = null, string
         echo "<script defer src='{$base}/assets/vendor/markdown-it-abbr.min.js'></script>";
         echo "<script defer src='{$base}/assets/vendor/markdown-it-ins.min.js'></script>";
         echo "<script defer src='{$base}/assets/vendor/markdown-it-container.min.js'></script>";
-        echo "<script defer src='{$base}/assets/vendor/markdown-it-multimd-table.min.js'></script>";
         echo "<script defer src='{$base}/assets/vendor/markdown-it-anchor.min.js'></script>";
         echo "<script defer src='{$base}/assets/vendor/katex.min.js'></script>";
         echo "<script defer src='{$base}/assets/vendor/highlight.min.js'></script>";


### PR DESCRIPTION
## Background
[Issue #22](https://github.com/b8l8u8e8/siyuan-plugin-share/issues/22)  reports that in V0.3.6, very long tables render with broken layout and incorrect column counts on shared pages. The issue includes a repro link, a test video (V0.3.6.bug.mp4), and an attachment (测试表格.xlsx).

## Changes
- Stop loading the `markdown-it-multimd-table` script on share pages
- Stop registering the `markdown-it-multimd-table` plugin in Markdown rendering

## Rationale
`markdown-it-multimd-table` interprets empty cells (`||`) as colspan. With long tables that contain many empty cells, this collapses columns and breaks layout. Falling back to standard `markdown-it` table parsing keeps column counts stable and avoids the issue.

## Behavior Impact
- Share tables fall back to standard Markdown table parsing
- `markdown-it-multimd-table` extensions (colspan/rowspan, multi-body, headerless tables, etc.) are no longer supported
- Other Markdown plugins remain unchanged
