### PR TITLE
fix rendering problem of maths fomulas in the notebook

### DIFF
--- a/php-site/index.php
+++ b/php-site/index.php
@@ -7093,7 +7093,7 @@ function route_share(string $slug, ?string $docId = null): void {
             $content .= $mainHtml;
             $content .= '</div>';
             record_share_access($share, null, $shareTitleRaw);
-            render_page($shareTitleRaw, $content, null, '', ['layout' => 'share']);
+            render_page($shareTitleRaw, $content, null, '', ['layout' => 'share', 'markdown' => true]);
         }
 
         $rows = '';
@@ -10884,3 +10884,4 @@ if ($path === '/') {
 
 http_response_code(404);
 echo '未找到。';
+


### PR DESCRIPTION
fix error: when first time opening a file in the notebook, maths formulas are not rendering correctly

直接github在线编辑的 就改了一行结果提示改了几百行 不懂 下次还是用git吧