### PR TITLE
fix: prevent premature termination of inline KaTeX expressions

### DIFF
--- a/php-site/assets/app.js
+++ b/php-site/assets/app.js
@@ -4646,6 +4646,18 @@ const initImageViewer = () => {
             match += 1;
             continue;
           }
+          // Skip $ inside braced groups (e.g. \text{...$...$...})
+          let braceDepth = 0;
+          for (let i = start; i < match; i++) {
+            const ch = state.src[i];
+            if (ch === "\\" && i + 1 < match) { i++; continue; }
+            if (ch === "{") braceDepth++;
+            else if (ch === "}") braceDepth--;
+          }
+          if (braceDepth !== 0) {
+            match += 1;
+            continue;
+          }
           const content = state.src.slice(start, match);
           if (!content.trim()) {
             match += 1;


### PR DESCRIPTION
<img width="604" alt="image" src="https://github.com/user-attachments/assets/70585c1a-8790-4f60-b292-5b438653680e" />

`$\bigcup_{\alpha \in J''}U_{\alpha}= \bigcup_{\alpha \in J''}(Y - C_{\alpha}) = Y - \underbrace{\bigcap_{\alpha \in J''} C_\alpha}_{\text{compact since $(*)$}} = Y - C$`

fix this rendering error